### PR TITLE
Update config and README after the transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Zola](https://www.getzola.org/documentation/getting-started/installation/).
 Then, clone this repository and move to the downloaded folder:
 
 ```bash
-git clone https://www.github.com/fatiando/2023-birs
-cd 2023-birs
+git clone https://www.github.com/softwareunderground/birs-2023
+cd birs-2023
 ```
 
 And use Zola to build and serve the website:

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://www.fatiando.org/2023-birs"
+base_url = "https://birs-2023.softwareunderground.org"
 
 title = "BIRS 2023 Workshop"
 


### PR DESCRIPTION
Set `base_url` to a subdomain of softwareunderground.org and update the instructions to build the website locally using the new repo.
