### PR TITLE
Define a temporary base_url to GH Pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,8 @@
 # The URL the site will be built for
-base_url = "https://birs-2023.softwareunderground.org"
+# base_url = "https://birs-2023.softwareunderground.org"
+
+# define a temporary base_url (until the website gets its own subdomain)
+base_url = "https://github.softwareunderground.io/birs-2023/"
 
 title = "BIRS 2023 Workshop"
 


### PR DESCRIPTION
This change should be reverted once the website gets its own subdomain
in softwareunderground.org.
