### PR TITLE
Add CNAME to static directory

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+birs-2023.softwareunderground.org


### PR DESCRIPTION
Adding the CNAME file to the static directory will keep the custom
domain configuration persistently after every deployment.
