### PR TITLE
Add table of contents to pages template

### DIFF
--- a/content/coc.md
+++ b/content/coc.md
@@ -1,9 +1,7 @@
 +++
-title = "BIRS 2023: Code of Conduct"
+title = "Code of Conduct"
 template = "page.html"
 +++
-
-# Code of Conduct
 
 All participants (including in-person and virtual participants) are required to
 abide the [BIRS's Code of Conduct][birs-coc].

--- a/content/information.md
+++ b/content/information.md
@@ -1,9 +1,8 @@
 +++
 title = "Information for Participants"
 template = "page.html"
+extra.show_toc = true
 +++
-
-# Information for Participants
 
 BIRS website has [several pages with information for
 participants][birs-info-participants], and also a [FAQ section][birs-faq].

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -3,6 +3,4 @@ title = "BIRS 2023: Schedule"
 template = "page.html"
 +++
 
-# Schedule
-
 We are working on it, stay tuned!

--- a/content/workshop.md
+++ b/content/workshop.md
@@ -1,9 +1,7 @@
 +++
-title = "BIRS 2023: Workshop"
+title = "The Workshop"
 template = "page.html"
 +++
-
-# The Workshop
 
 ## Description
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -46,6 +46,10 @@
     gap: 1em;
 }
 
+.gap-2em {
+    gap: 2em;
+}
+
 /* ------------ */
 /* Custom style */
 /* ------------ */
@@ -129,6 +133,13 @@ nav li {
 
 header {
   background-color: var(--background-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+header.home {
   height: calc(100vh - 90px);
   display: flex;
   flex-direction: column;
@@ -366,4 +377,25 @@ main.home {
 
 .admonition .title {
     color: var(--primary);
+}
+
+.toc nav {
+    position: sticky;
+    top: 5em;
+    border-right: 2px solid var(--muted-border-color);
+    padding-right: 2em;
+}
+
+.toc nav a {
+  color: var(--primary-color);
+}
+
+.toc nav a:hover {
+  color: var(--primary-hover);
+}
+
+@media (max-width: 992px) {
+    .toc  {
+        display: none;
+    }
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,7 +4,7 @@
 
 {% include "navbar.html" %}
 
-<header data-theme="dark">
+<header class="home" data-theme="dark">
   <div class="container banner">
     <h1>
       BIRS Workshop:

--- a/templates/page.html
+++ b/templates/page.html
@@ -10,9 +10,47 @@
 
 {% include "navbar.html" %}
 
+<header data-theme="dark">
+  <h1>{{ page.title }}</h1>
+</header>
+
+{% if page.extra.show_toc %}
+
+<main class="container dflex flex-row gap-2em">
+  <aside class="toc">
+    <nav>
+      <ul>
+      {% for h1 in page.toc %}
+        <li>
+          <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+          {% if h1.children %}
+            <ul>
+              {% for h2 in h1.children %}
+                <li>
+                    <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </li>
+      {% endfor %}
+      </ul>
+    </nav>
+  </aside>
+
+  <div>
+  {{ page.content | safe }}
+  </div>
+
+</main>
+
+{% else %}
+
 <main class="container">
   {{ page.content | safe }}
 </main>
+
+{% endif %}
 
 {% include "footer.html" %}
 


### PR DESCRIPTION
Modify the page.html template: the h1 heading is inherited from the title. Add a new `extra.show_toc` option to enable the toc. Add a toc to `information.md`. The toc only includes headers up to h2.
