### PR TITLE
Update links to SimPEG website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ url = "https://www.fatiando.org"
 
 [extra.simpeg]
 name = "SimPEG"
-url = "https://www.simpeg.xyz"
+url = "https://simpeg.xyz"
 
 [extra.birs]
 name = "BIRS"

--- a/content/coc.md
+++ b/content/coc.md
@@ -22,4 +22,4 @@ religion, or sexual identity and orientation.
 [fatiando-coc]: https://github.com/fatiando/community/blob/main/CODE_OF_CONDUCT.md
 [simpeg-coc]: https://github.com/simpeg/simpeg/blob/main/CODE_OF_CONDUCT.md
 [fatiando]: https://www.fatiando.org
-[simpeg]: https://www.simpeg.xyz
+[simpeg]: https://simpeg.xyz

--- a/content/workshop.md
+++ b/content/workshop.md
@@ -69,4 +69,4 @@ generation of developers and contributors.
 
 [birs]: https://www.birs.ca
 [fatiando]: https://www.fatiando.org
-[simpeg]: https://www.simpeg.xyz
+[simpeg]: https://simpeg.xyz

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,7 +36,7 @@
       We are happy to announce a <strong>2 day workshop</strong> in
       which the communities of
       <a href="https://www.fatiando.org">Fatiando a Terra</a> and
-      <a href="https://wwww.simpeg.xyz">SimPEG</a> will join together to
+      <a href="https://simpeg.xyz">SimPEG</a> will join together to
       set the roadmap for enhancing open-source tools for geophysics.
       The workshop will take place at the
       <a href="https://www.birs.ca"
@@ -186,7 +186,7 @@
         <img src="images/simpeg.png" alt="SimPEG" />
         <h3>SimPEG</h3>
         <p>Simulation and Parameter Estimation in Geophysics</p>
-        <a href="https://www.simpeg.xyz">simpeg.xyz</a>
+        <a href="https://simpeg.xyz">simpeg.xyz</a>
       </div>
       <div class="community-card">
         <img src="images/birs.png" alt="BIRS" />


### PR DESCRIPTION
Main bug was the `wwww.simpeg.xyz`, updated others to point to the main domain without a redirect.